### PR TITLE
Update ClusterRoleBinding and ClusterRole apiVersion

### DIFF
--- a/manifest/prometheus-0serviceaccount.yaml
+++ b/manifest/prometheus-0serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
 ---
 # The ClusterRole grants the Prometheus Service Account permissions to fetch Kubernetes Node information, 
 # as well as information about Services, Endpoints, and Pods in the cluster.
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: prometheus
@@ -24,7 +24,7 @@ rules:
 - nonResourceURLs: ["/metrics", "/metrics/cadvisor"]
   verbs: ["get"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus


### PR DESCRIPTION
v1beta1 is deprecated and will be removed in k8s 1.22.  This updates
them to the new (correct) version